### PR TITLE
fix: kernel buffer flush & draw in panic handler

### DIFF
--- a/src/console/console_manager.rs
+++ b/src/console/console_manager.rs
@@ -84,4 +84,8 @@ impl ConsoleManager {
 			console.flush();
 		}
 	}
+
+	pub fn flush_foreground(&mut self) {
+		self.cons[self.foreground].flush();
+	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,11 +24,16 @@ use input::{key_event::Code, keyboard::KEYBOARD};
 /// we should make sure no more `panic!()` from here.
 #[panic_handler]
 fn panic_handler_impl(info: &PanicInfo) -> ! {
-	unsafe { CONSOLE_MANAGER.get().set_foreground(CONSOLE_COUNTS - 1) };
-
+	
 	printk_panic!("{}\ncall stack (most recent call first)\n", info);
 	print_stacktrace!();
-
+	
+	unsafe { 
+		CONSOLE_MANAGER.get().set_foreground(CONSOLE_COUNTS - 1);
+		CONSOLE_MANAGER.get().flush_foreground();
+		CONSOLE_MANAGER.get().draw();
+	};
+	
 	loop {}
 }
 
@@ -69,6 +74,7 @@ pub fn kernel_entry(bi_header: usize, magic: u32) -> ! {
 					pr_warn!("BACKTICK PRESSED {} TIMES!!", I);
 					I += 1;
 				}
+				panic!();
 			}
 			text_vga::putc(24, 79, cyan);
 			unsafe {

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,6 @@ pub fn kernel_entry(bi_header: usize, magic: u32) -> ! {
 					pr_warn!("BACKTICK PRESSED {} TIMES!!", I);
 					I += 1;
 				}
-				panic!();
 			}
 			text_vga::putc(24, 79, cyan);
 			unsafe {


### PR DESCRIPTION
demesg에 있는 버퍼를 flush하는 작업 없이 panic handler에서 foreground console만 바꿔 아무 것도 출력이 안됐습니다.

그래서 flush, draw로직을 추가하였습니다.
