### PR TITLE
feat: memory allocator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![no_main]
 #![allow(dead_code)]
 #![feature(allocator_api)]
-#![feature(adt_const_params)] // GFP to const generic params
 #![feature(maybe_uninit_uninit_array)]
 #![feature(const_maybe_uninit_uninit_array)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 #![no_main]
 #![allow(dead_code)]
 #![feature(allocator_api)]
+#![feature(adt_const_params)] // GFP to const generic params
+#![feature(maybe_uninit_uninit_array)]
+#![feature(const_maybe_uninit_uninit_array)]
 
 extern crate alloc;
 

--- a/src/mm.rs
+++ b/src/mm.rs
@@ -6,5 +6,8 @@ pub use page_allocator::{Page, PageAllocator, GFP, PAGE_ALLOC};
 pub mod cache_allocator;
 pub mod constant;
 pub mod global_allocator;
+pub mod memory_allocator;
 pub mod util;
 pub mod x86;
+
+pub mod kmalloc;

--- a/src/mm/cache_allocator.rs
+++ b/src/mm/cache_allocator.rs
@@ -7,5 +7,183 @@ mod util;
 pub const REGISTER_TRY: usize = 3; // TODO config?
 
 pub use cache_manager::CM;
-pub use size_cache::{SizeCache, SizeCacheTrait};
+pub use size_cache::SizeCache;
+pub use traits::{CacheStat, CacheTrait};
 pub use util::{alloc_block_from_page_alloc, dealloc_block_to_page_alloc};
+
+use core::array::from_fn;
+use core::mem::MaybeUninit;
+use core::ptr::NonNull;
+use core::sync::atomic::Ordering;
+use core::{alloc::AllocError, sync::atomic::AtomicBool};
+
+use super::memory_allocator::util::{LEVEL_END, LEVEL_MIN};
+use crate::new_cache_allocator;
+
+#[derive(Debug)]
+pub struct CacheAllocator {
+	initialized: AtomicBool,
+	cache: [MaybeUninit<NonNull<dyn CacheTrait>>; 6],
+}
+
+impl CacheAllocator {
+	pub const fn new() -> Self {
+		let initialized = AtomicBool::new(false);
+		let cache = MaybeUninit::uninit_array::<6>();
+
+		CacheAllocator { initialized, cache }
+	}
+
+	pub fn statistic(&mut self) -> CacheAllocatorStat {
+		let cache = &mut self.cache;
+		let initialized = self.initialized.load(Ordering::Relaxed);
+
+		let cache_stat = match initialized {
+			true => from_fn(|i| unsafe { cache[i].assume_init_mut().as_mut().statistic() }),
+			false => from_fn(|_| CacheStat::hand_made(0, 0, 0)),
+		};
+
+		CacheAllocatorStat {
+			initialized,
+			cache_stat,
+		}
+	}
+
+	pub fn allocate(&mut self, level: usize) -> Result<NonNull<[u8]>, AllocError> {
+		unsafe { self.lazy_init() };
+
+		match level.checked_sub(LEVEL_END) {
+			None => self.get_allocator(level).allocate(),
+			Some(_) => panic!("invalid request!"),
+		}
+	}
+
+	/// # Safety
+	///
+	/// `ptr` must point memory allocated by `self`.
+	pub unsafe fn deallocate(&mut self, ptr: NonNull<u8>, level: usize) {
+		self.lazy_init();
+
+		match level.checked_sub(LEVEL_END) {
+			None => self.get_allocator(level).deallocate(ptr),
+			Some(_) => panic!("invalid request!"),
+		}
+	}
+
+	unsafe fn lazy_init(&mut self) {
+		if !self.initialized.load(Ordering::Relaxed) {
+			let cache = &mut self.cache;
+			cache[0].write(new_cache_allocator!(64));
+			cache[1].write(new_cache_allocator!(128));
+			cache[2].write(new_cache_allocator!(256));
+			cache[3].write(new_cache_allocator!(512));
+			cache[4].write(new_cache_allocator!(1024));
+			cache[5].write(new_cache_allocator!(2048));
+
+			self.initialized.store(true, Ordering::Relaxed)
+		}
+	}
+
+	fn get_allocator(&mut self, level: usize) -> &mut dyn CacheTrait {
+		match level {
+			6..=11 => unsafe { self.cache[level - LEVEL_MIN].assume_init_mut().as_mut() },
+			_ => panic!("invalid level!"),
+		}
+	}
+}
+
+#[macro_export]
+macro_rules! new_cache_allocator {
+	($size: literal) => {
+		CM.new_allocator::<SizeCache<$size>>()
+			.expect("out of memory.") // FIXME
+	};
+}
+
+impl Drop for CacheAllocator {
+	fn drop(&mut self) {
+		unsafe {
+			if self.initialized.load(Ordering::Relaxed) {
+				for c in self.cache.iter() {
+					CM.drop_allocator(c.assume_init());
+				}
+			}
+		}
+	}
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CacheAllocatorStat {
+	initialized: bool,
+	cache_stat: [CacheStat; 6],
+}
+
+impl CacheAllocatorStat {
+	pub const fn hand_made(initialized: bool, cache: [CacheStat; 6]) -> Self {
+		Self {
+			initialized,
+			cache_stat: cache,
+		}
+	}
+}
+
+mod tests {
+	use super::*;
+	use crate::mm::{
+		cache_allocator::{CacheAllocatorStat, CacheStat},
+		constant::PAGE_SIZE,
+	};
+	use kfs_macro::ktest;
+
+	#[ktest]
+	fn alloc_dealloc_cache() {
+		for level in LEVEL_MIN..LEVEL_END {
+			let mut cache = CacheAllocator::new();
+			let mut cache_stat = core::array::from_fn(|_| CacheStat::hand_made(0, 0, 0));
+			let total = PAGE_SIZE / (1 << level) - 1;
+			cache_stat[level - LEVEL_MIN] = CacheStat::hand_made(1, total, 1);
+
+			let ptr = cache.allocate(level);
+
+			assert_eq!(
+				cache.statistic(),
+				CacheAllocatorStat::hand_made(true, cache_stat)
+			);
+
+			// if not dealloc, then panic! will be called.
+			unsafe { cache.deallocate(ptr.unwrap().cast(), level) };
+
+			cache_stat[level - LEVEL_MIN] = CacheStat::hand_made(1, total, 0);
+			assert_eq!(
+				cache.statistic(),
+				CacheAllocatorStat::hand_made(true, cache_stat)
+			);
+		}
+	}
+
+	#[ktest]
+	fn alloc_twice() {
+		let level = 8;
+		let mut cache = CacheAllocator::new();
+		let mut cache_stat = core::array::from_fn(|_| CacheStat::hand_made(0, 0, 0));
+		let total = PAGE_SIZE / (1 << level) - 1;
+		cache_stat[level - LEVEL_MIN] = CacheStat::hand_made(1, total, 2);
+
+		let ptr = [cache.allocate(level), cache.allocate(level)];
+
+		assert_eq!(
+			cache.statistic(),
+			CacheAllocatorStat::hand_made(true, cache_stat)
+		);
+
+		// if not dealloc, then panic! will be called.
+		unsafe { cache.deallocate(ptr[0].unwrap().cast(), level) };
+		unsafe { cache.deallocate(ptr[1].unwrap().cast(), level) };
+
+		cache_stat[level - LEVEL_MIN] = CacheStat::hand_made(1, total, 0);
+		assert_eq!(
+			cache.statistic(),
+			CacheAllocatorStat::hand_made(true, cache_stat)
+		);
+	}
+}

--- a/src/mm/cache_allocator/size_cache.rs
+++ b/src/mm/cache_allocator/size_cache.rs
@@ -251,13 +251,13 @@ pub mod tests {
 		let mut cache = SizeCache::<SIZE>::new();
 
 		// reserve for one cache.
-		// META_CACHE_SIZE + SizeCache<SIZE, {GFP::Normal}>::SIZE = 32 + 2048 = 2032 => rank 0
+		// META_CACHE_SIZE + SizeCache<SIZE>::SIZE = 32 + 2048 = 2032 => rank 0
 		cache.reserve(1).unwrap();
 		assert_eq!(cache.partial.count(), 1);
 		head_check(&mut cache, 0, 0);
 
 		//reserve for three cache.
-		// META_CACHE_SIZE + SizeCache<SIZE, {GFP::Normal}>::SIZE * 3 = 32 + 2048 * 3 = 6176 => rank 1
+		// META_CACHE_SIZE + SizeCache<SIZE>::SIZE * 3 = 32 + 2048 * 3 = 6176 => rank 1
 		cache.reserve(3).unwrap();
 		assert_eq!(cache.partial.count(), 2);
 		head_check(&mut cache, 0, 1);

--- a/src/mm/cache_allocator/size_cache.rs
+++ b/src/mm/cache_allocator/size_cache.rs
@@ -1,11 +1,11 @@
 use core::alloc::AllocError;
-use core::marker::PhantomData;
 use core::mem::size_of;
 use core::ptr::NonNull;
 
 use crate::mm::constant::PAGE_SIZE;
+use crate::mm::GFP;
 
-use super::traits::{CacheInit, CacheTrait};
+use super::traits::{CacheInit, CacheStat, CacheTrait};
 use super::util::no_alloc_list::{NAList, Node};
 use super::util::{align_with_hw_cache, alloc_block_from_page_alloc};
 
@@ -14,13 +14,12 @@ use super::meta_cache::MetaCache;
 type Result<T> = core::result::Result<T, AllocError>;
 
 #[derive(Debug)]
-pub struct SizeCache<'page, const N: usize> {
+pub struct SizeCache<const N: usize> {
 	partial: NAList<MetaCache>,
 	page_count: usize,
-	phantom: PhantomData<&'page usize>,
 }
 
-impl<'page, const N: usize> SizeCache<'page, N> {
+impl<const N: usize> SizeCache<N> {
 	const SIZE: usize = align_with_hw_cache(N);
 	const RANK: usize = rank_of(Self::SIZE);
 
@@ -28,7 +27,6 @@ impl<'page, const N: usize> SizeCache<'page, N> {
 		SizeCache {
 			partial: NAList::new(),
 			page_count: 0,
-			phantom: PhantomData,
 		}
 	}
 
@@ -36,60 +34,43 @@ impl<'page, const N: usize> SizeCache<'page, N> {
 		let rank = rank_of(Self::SIZE * count);
 		let page = self.alloc_pages(rank)?;
 		unsafe {
-			let node = Node::alloc_at(page.0);
+			let node = Node::alloc_at(page.cast());
 			self.partial.push_front(node);
-			MetaCache::construct_at(page.0, Self::SIZE);
+			MetaCache::construct_at(page.cast(), Self::SIZE);
 		};
 		Ok(())
 	}
 
-	pub fn alloc(&mut self) -> Result<NonNull<u8>> {
-		let meta_cache = self.partial.head().and_then(|mut meta_cache_ptr| {
-			let meta_cache = unsafe { meta_cache_ptr.as_mut() };
-			match meta_cache.is_full() {
-				true => None,
-				false => Some(meta_cache_ptr),
-			}
-		});
-
-		meta_cache
-			.or_else(|| {
-				let page = self.alloc_pages(Self::RANK).ok()?;
-				let ptr = unsafe {
-					let node = Node::alloc_at(page.0);
-					self.partial.push_front(node);
-
-					let meta_cache = MetaCache::construct_at(page.0, Self::SIZE);
-					NonNull::new_unchecked(meta_cache)
-				};
-				Some(ptr)
-			})
-			.map(|mut meta_cache_ptr| {
-				let meta_cache = unsafe { meta_cache_ptr.as_mut() };
-				meta_cache.alloc().unwrap()
-			})
-			.ok_or(AllocError)
-	}
-
-	/// # Safety
-	///
-	/// `ptr` must point a memory block allocated by `self`.
-	pub unsafe fn dealloc(&mut self, ptr: NonNull<u8>) {
+	fn get_meta_cache(&mut self) -> Option<NonNull<MetaCache>> {
 		self.partial
-			.find(|meta_cache| meta_cache.contains(ptr))
-			.map(|meta_cache| {
-				meta_cache.dealloc(ptr);
-			});
+			.head()
+			.and_then(|mut meta_cache_ptr| {
+				let meta_cache = unsafe { meta_cache_ptr.as_mut() };
+				match meta_cache.is_full() {
+					true => None,
+					false => Some(meta_cache_ptr),
+				}
+			})
+			.or_else(|| unsafe {
+				let page = self.alloc_pages(Self::RANK).ok()?;
+				let node = Node::alloc_at(page.cast());
+				self.partial.push_front(node);
+
+				let meta_cache = MetaCache::construct_at(page.cast(), Self::SIZE);
+				Some(NonNull::new_unchecked(meta_cache))
+			})
 	}
 
-	fn alloc_pages(&mut self, rank: usize) -> Result<(NonNull<u8>, usize)> {
-		let page = alloc_block_from_page_alloc(rank)?;
+	fn alloc_pages(&mut self, rank: usize) -> Result<NonNull<[u8]>> {
+		let page = alloc_block_from_page_alloc(rank, GFP::Normal)?;
 		self.page_count += 1 << rank;
 		Ok(page)
 	}
 }
 
-impl<'page, const N: usize> CacheTrait for SizeCache<'_, N> {
+impl<const N: usize> CacheInit for SizeCache<N> {}
+
+impl<const N: usize> CacheTrait for SizeCache<N> {
 	fn partial(&mut self) -> &mut NAList<MetaCache> {
 		&mut self.partial
 	}
@@ -97,15 +78,48 @@ impl<'page, const N: usize> CacheTrait for SizeCache<'_, N> {
 	fn empty(&self) -> bool {
 		self.partial.head() == None
 	}
+
+	fn statistic(&self) -> CacheStat {
+		let (total, inuse) = self.partial.iter().fold((0, 0), |(mut t, mut i), m| {
+			i += m.inuse;
+			t += m.total();
+			(t, i)
+		});
+
+		CacheStat {
+			page_count: self.page_count,
+			total,
+			inuse,
+		}
+	}
+
+	fn allocate(&mut self) -> Result<NonNull<[u8]>> {
+		let mut meta_cache_ptr = self.get_meta_cache().ok_or(AllocError)?;
+		let meta_cache = unsafe { meta_cache_ptr.as_mut() };
+		meta_cache.alloc()
+	}
+
+	/// # Safety
+	///
+	/// `ptr` must point a memory block allocated by `self`.
+	unsafe fn deallocate(&mut self, ptr: NonNull<u8>) {
+		self.partial
+			.remove_if(|meta_cache| meta_cache.contains(ptr))
+			.map(|mut node| {
+				let meta_cache = unsafe { node.cast::<MetaCache>().as_mut() };
+				meta_cache.dealloc(ptr);
+
+				let node = unsafe { node.as_mut() };
+				self.partial.push_front(node);
+			});
+	}
 }
 
-impl<'page, const N: usize> Default for SizeCache<'_, N> {
+impl<const N: usize> Default for SizeCache<N> {
 	fn default() -> Self {
 		Self::new()
 	}
 }
-
-impl<'page, const N: usize> CacheInit for SizeCache<'_, N> {}
 
 const fn rank_of(size: usize) -> usize {
 	const NODE_SIZE: usize = size_of::<Node<MetaCache>>();
@@ -120,24 +134,6 @@ const fn rank_of(size: usize) -> usize {
 		rank += 1;
 	}
 	rank
-}
-
-pub trait SizeCacheTrait {
-	fn allocate(&mut self) -> *mut u8;
-	unsafe fn deallocate(&mut self, ptr: *mut u8);
-}
-
-impl<'page, const N: usize> SizeCacheTrait for SizeCache<'page, N> {
-	fn allocate(&mut self) -> *mut u8 {
-		match self.alloc() {
-			Ok(ptr) => ptr.as_ptr(),
-			Err(_) => core::ptr::null_mut(),
-		}
-	}
-
-	unsafe fn deallocate(&mut self, ptr: *mut u8) {
-		self.dealloc(NonNull::new_unchecked(ptr));
-	}
 }
 
 pub mod tests {
@@ -157,7 +153,7 @@ pub mod tests {
 
 	pub fn head_check(cache: &mut dyn CacheTrait, inuse: usize, rank: usize) {
 		let head = get_head(cache);
-		let max = (size_of_rank(head.rank()) - MetaCache::NODE_ALIGN) / head.cache_size;
+		let max = (size_of_rank(head.rank()) - MetaCache::META_SIZE) / head.cache_size;
 
 		assert_eq!(head.free_list.count(), max - inuse);
 		assert_eq!(head.inuse, inuse);
@@ -186,14 +182,14 @@ pub mod tests {
 
 		for i in 0..MAX_COUNT {
 			// 64 * 63 => 4032 + meta_cache(16) => full
-			let _ = cache.alloc();
+			let _ = cache.allocate();
 			assert_eq!(cache.page_count, 1);
 			assert_eq!(cache.partial.count(), 1);
 
 			head_check(&mut cache, i + 1, 0);
 		}
 
-		let _ = cache.alloc();
+		let _ = cache.allocate();
 		assert_eq!(cache.page_count, 2);
 		assert_eq!(cache.partial.count(), 2);
 
@@ -207,9 +203,9 @@ pub mod tests {
 		let mut cache = SizeCache::<SIZE>::new();
 
 		// dealloc one when the inuse is 1.
-		let ptr = cache.alloc();
+		let ptr = cache.allocate();
 		head_check(&mut cache, 1, 0);
-		unsafe { cache.dealloc(ptr.unwrap()) };
+		unsafe { cache.deallocate(ptr.unwrap().cast()) };
 
 		assert_eq!(cache.partial.count(), 1);
 		head_check(&mut cache, 0, 0);
@@ -217,11 +213,11 @@ pub mod tests {
 		// dealloc one when the inuse of 2nd memory block is 1.
 		let mut ptrs: [NonNull<u8>; 64] = [NonNull::dangling(); 64];
 		for i in 0..MAX_COUNT {
-			ptrs[i] = cache.alloc().unwrap();
+			ptrs[i] = cache.allocate().unwrap().cast();
 		}
 
-		let ptr = cache.alloc();
-		unsafe { cache.dealloc(ptr.unwrap()) };
+		let ptr = cache.allocate();
+		unsafe { cache.deallocate(ptr.unwrap().cast()) };
 
 		assert_eq!(cache.partial.count(), 2);
 		head_check(&mut cache, 0, 0);
@@ -229,11 +225,11 @@ pub mod tests {
 		// dealloc whole in one memory block.
 		for i in 0..MAX_COUNT {
 			let ptr = ptrs[i];
-			unsafe { cache.dealloc(ptr) };
+			unsafe { cache.deallocate(ptr.cast()) };
 
-			let last = cache.partial.iter().last().unwrap();
-			assert_eq!(last.free_list.count(), i + 1);
-			assert_eq!(last.inuse, MAX_COUNT - (i + 1));
+			let head = unsafe { cache.partial.head().unwrap().as_mut() };
+			assert_eq!(head.free_list.count(), i + 1);
+			assert_eq!(head.inuse, MAX_COUNT - (i + 1));
 		}
 	}
 
@@ -241,7 +237,7 @@ pub mod tests {
 	fn test_alloc_bound() {
 		fn do_test<const N: usize>(rank: usize) {
 			let mut cache = SizeCache::<N>::new();
-			let _ = cache.alloc();
+			let _ = cache.allocate();
 			head_check(&mut cache, 1, rank);
 		}
 		do_test::<4032>(0);
@@ -255,13 +251,13 @@ pub mod tests {
 		let mut cache = SizeCache::<SIZE>::new();
 
 		// reserve for one cache.
-		// META_CACHE_SIZE + SizeCache<SIZE>::SIZE = 32 + 2048 = 2032 => rank 0
+		// META_CACHE_SIZE + SizeCache<SIZE, {GFP::Normal}>::SIZE = 32 + 2048 = 2032 => rank 0
 		cache.reserve(1).unwrap();
 		assert_eq!(cache.partial.count(), 1);
 		head_check(&mut cache, 0, 0);
 
 		//reserve for three cache.
-		// META_CACHE_SIZE + SizeCache<SIZE>::SIZE * 3 = 32 + 2048 * 3 = 6176 => rank 1
+		// META_CACHE_SIZE + SizeCache<SIZE, {GFP::Normal}>::SIZE * 3 = 32 + 2048 * 3 = 6176 => rank 1
 		cache.reserve(3).unwrap();
 		assert_eq!(cache.partial.count(), 2);
 		head_check(&mut cache, 0, 1);
@@ -279,22 +275,22 @@ pub mod tests {
 
 		// shrink one memory block.
 		let mut cache = SizeCache::<SIZE>::new();
-		let ptr = cache.alloc().unwrap();
-		unsafe { cache.dealloc(ptr) }
+		let ptr = cache.allocate().unwrap();
+		unsafe { cache.deallocate(ptr.cast()) }
 		meta_cache_count_check(&mut cache, 1);
 
 		// shrink two memory block.
 		const MAX_COUNT: usize = 3;
 		let mut ptrs: [NonNull<u8>; MAX_COUNT] = [NonNull::dangling(); MAX_COUNT];
 		for i in 0..MAX_COUNT {
-			ptrs[i] = cache.alloc().unwrap();
+			ptrs[i] = cache.allocate().unwrap().cast();
 		}
-		let ptr = cache.alloc().unwrap();
+		let ptr = cache.allocate().unwrap();
 		unsafe {
-			cache.dealloc(ptr);
+			cache.deallocate(ptr.cast());
 
 			for i in 0..MAX_COUNT {
-				cache.dealloc(ptrs[i]);
+				cache.deallocate(ptrs[i]);
 			}
 		}
 		meta_cache_count_check(&mut cache, 2);

--- a/src/mm/cache_allocator/traits.rs
+++ b/src/mm/cache_allocator/traits.rs
@@ -37,7 +37,8 @@ pub trait CacheInit: Default {
 	/// Initialization function for cache allocator.
 	///
 	/// # Safety
-	/// The memory pointed by `ptr` must be reserved for cache allocator.
+	/// * The memory pointed by `ptr` must be reserved for cache allocator.
+	/// * Because `Self::default` makes a temporal instance, When you implement `drop` trait, be careful.
 	unsafe fn construct_at<'a>(ptr: NonNull<u8>) -> &'a mut Self {
 		let ptr = ptr.as_ptr() as *mut Self;
 		(*ptr) = Self::default();

--- a/src/mm/global_allocator.rs
+++ b/src/mm/global_allocator.rs
@@ -1,25 +1,9 @@
+use core::alloc::Allocator;
 use core::alloc::GlobalAlloc;
 use core::alloc::Layout;
-use core::cell::UnsafeCell;
 use core::ptr::NonNull;
 
-use crate::kmem_cache_register;
-
-use super::cache_allocator::alloc_block_from_page_alloc;
-use super::cache_allocator::dealloc_block_to_page_alloc;
-use super::cache_allocator::SizeCache;
-use super::cache_allocator::SizeCacheTrait;
-use super::util::bit_scan_reverse;
-
-static mut SIZE64: SizeCache<'static, 64> = SizeCache::new(); // LEVEL 6
-static mut SIZE128: SizeCache<'static, 128> = SizeCache::new();
-static mut SIZE256: SizeCache<'static, 256> = SizeCache::new();
-static mut SIZE512: SizeCache<'static, 512> = SizeCache::new();
-static mut SIZE1024: SizeCache<'static, 1024> = SizeCache::new();
-static mut SIZE2048: SizeCache<'static, 2048> = SizeCache::new(); // LEVEL 11
-
-const LEVEL_MIN: usize = 6;
-const LEVEL_END: usize = 12;
+use super::memory_allocator::mem_normal::MemNormal;
 
 /// trait Allocator vs trait GlobalAlloc
 ///
@@ -28,86 +12,25 @@ const LEVEL_END: usize = 12;
 /// proc-macro [global_allocator] requires trait [core::alloc::GlobalAlloc], not trait [core::alloc::Allocator].
 
 #[global_allocator]
-pub static G: GlobalAllocator = GlobalAllocator::new();
+pub static G: MemGlobal = MemGlobal;
 
-pub struct GlobalAllocator(UnsafeCell<bool>); // TODO Atomic?
+unsafe impl Sync for MemGlobal {} // FIXME ?
 
-unsafe impl Sync for GlobalAllocator {} // ?
+pub struct MemGlobal;
 
-impl GlobalAllocator {
-	pub const fn new() -> Self {
-		GlobalAllocator(UnsafeCell::new(false))
-	}
-
-	pub unsafe fn lazy_init(&self) {
-		if !*self.0.get() {
-			kmem_cache_register!(SIZE2048);
-			kmem_cache_register!(SIZE1024);
-			kmem_cache_register!(SIZE512);
-			kmem_cache_register!(SIZE256);
-			kmem_cache_register!(SIZE128);
-			kmem_cache_register!(SIZE64);
-			(*self.0.get()) = true;
-		}
-	}
-}
-
-unsafe impl GlobalAlloc for GlobalAllocator {
+unsafe impl GlobalAlloc for MemGlobal {
 	unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-		self.lazy_init();
-
-		let level = level_of(layout);
-		match level.checked_sub(LEVEL_END) {
-			None => get_allocator(level).allocate(),
-			Some(rank) => match alloc_block_from_page_alloc(rank) {
-				Ok((ptr, _)) => ptr.as_ptr(),
-				Err(_) => core::ptr::null_mut(),
-			},
+		match MemNormal.allocate(layout) {
+			Ok(p) => p.as_ptr().cast(),
+			Err(_) => 0 as *mut u8,
 		}
 	}
-
 	unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-		self.lazy_init();
-
 		if ptr.is_null() {
 			return;
 		}
 
 		let ptr = NonNull::new_unchecked(ptr);
-		let level = level_of(layout);
-		match level < LEVEL_END {
-			true => get_allocator(level).deallocate(ptr.as_ptr()),
-			false => dealloc_block_to_page_alloc(ptr),
-		}
+		MemNormal.deallocate(ptr, layout)
 	}
-}
-
-unsafe fn get_allocator<'a>(level: usize) -> &'a mut dyn SizeCacheTrait {
-	let caches: [&mut dyn SizeCacheTrait; 6] = [
-		&mut SIZE64,
-		&mut SIZE128,
-		&mut SIZE256,
-		&mut SIZE512,
-		&mut SIZE1024,
-		&mut SIZE2048,
-	];
-	caches[level - LEVEL_MIN]
-}
-
-fn level_of(layout: Layout) -> usize {
-	let size = layout.size();
-	let align = layout.align();
-
-	if size <= 1 && align == 1 {
-		return LEVEL_MIN;
-	}
-
-	let rank = unsafe {
-		match size > align {
-			true => bit_scan_reverse(size - 1) + 1,
-			false => bit_scan_reverse(align - 1) + 1,
-		}
-	};
-
-	LEVEL_MIN + rank.checked_sub(LEVEL_MIN).unwrap_or_default()
 }

--- a/src/mm/kmalloc.rs
+++ b/src/mm/kmalloc.rs
@@ -3,12 +3,7 @@ use core::{
 	ptr::NonNull,
 };
 
-use super::memory_allocator::{mem_atomic::MemAtomic, mem_normal::MemNormal};
-
-pub enum GFP {
-	Atomic,
-	Normal,
-}
+use super::memory_allocator::{mem_atomic::MemAtomic, mem_normal::MemNormal, util::GFP};
 
 pub fn kmalloc(layout: Layout, flag: GFP) -> Result<NonNull<[u8]>, AllocError> {
 	match flag {

--- a/src/mm/kmalloc.rs
+++ b/src/mm/kmalloc.rs
@@ -1,0 +1,25 @@
+use core::{
+	alloc::{AllocError, Allocator, Layout},
+	ptr::NonNull,
+};
+
+use super::memory_allocator::{mem_atomic::MemAtomic, mem_normal::MemNormal};
+
+pub enum GFP {
+	Atomic,
+	Normal,
+}
+
+pub fn kmalloc(layout: Layout, flag: GFP) -> Result<NonNull<[u8]>, AllocError> {
+	match flag {
+		GFP::Atomic => MemAtomic.allocate(layout),
+		GFP::Normal => MemNormal.allocate(layout),
+	}
+}
+
+pub unsafe fn kfree(ptr: NonNull<u8>, layout: Layout, flag: GFP) {
+	match flag {
+		GFP::Atomic => MemAtomic.deallocate(ptr, layout),
+		GFP::Normal => MemNormal.deallocate(ptr, layout),
+	}
+}

--- a/src/mm/memory_allocator.rs
+++ b/src/mm/memory_allocator.rs
@@ -1,0 +1,192 @@
+pub mod mem_atomic;
+pub mod mem_normal;
+pub mod util;
+
+use core::alloc::{AllocError, Allocator, Layout};
+use core::cell::UnsafeCell;
+use core::ptr::NonNull;
+
+use self::util::{level_of, LEVEL_END};
+
+use super::cache_allocator::{alloc_block_from_page_alloc, dealloc_block_to_page_alloc};
+use super::cache_allocator::{CacheAllocator, CacheAllocatorStat};
+use super::page_allocator::MAX_RANK;
+use super::GFP;
+
+#[derive(Debug)]
+pub struct MemoryAllocator {
+	cache: UnsafeCell<CacheAllocator>,
+	rank_count: UnsafeCell<[usize; MAX_RANK + 1]>,
+}
+
+impl MemoryAllocator {
+	pub const fn new() -> Self {
+		let rank_count = UnsafeCell::new([0; MAX_RANK + 1]);
+
+		MemoryAllocator {
+			cache: UnsafeCell::new(CacheAllocator::new()),
+			rank_count,
+		}
+	}
+
+	pub fn statistic(&self) -> MemoryAllocatorStat {
+		let (cache, rank) = unsafe { self.get_fields() };
+
+		let rank_stat = rank.clone();
+		let cache_stat = cache.statistic();
+
+		MemoryAllocatorStat {
+			cache_stat,
+			rank_stat,
+		}
+	}
+
+	unsafe fn get_fields(&self) -> (&mut CacheAllocator, &mut [usize; MAX_RANK + 1]) {
+		(
+			self.cache.get().as_mut().unwrap(),
+			self.rank_count.get().as_mut().unwrap(),
+		)
+	}
+}
+
+impl Drop for MemoryAllocator {
+	fn drop(&mut self) {
+		if (self.rank_count.get_mut()).iter().sum::<usize>() != 0 {
+			panic!("It can cause memory leak!");
+		}
+	}
+}
+
+unsafe impl Allocator for MemoryAllocator {
+	fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+		let (cache, rank_count) = unsafe { self.get_fields() };
+
+		let level = level_of(layout);
+		match level.checked_sub(LEVEL_END) {
+			None => cache.allocate(level),
+			Some(rank) => {
+				rank_count[rank] += 1;
+				alloc_block_from_page_alloc(rank, GFP::Normal)
+			}
+		}
+	}
+
+	unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+		let (cache, rank_count) = self.get_fields();
+
+		let level = level_of(layout);
+		match level.checked_sub(LEVEL_END) {
+			None => cache.deallocate(ptr, level),
+			Some(rank) => {
+				rank_count[rank] -= 1;
+				dealloc_block_to_page_alloc(ptr);
+			}
+		}
+	}
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemoryAllocatorStat {
+	cache_stat: CacheAllocatorStat,
+	rank_stat: [usize; MAX_RANK + 1],
+}
+
+impl MemoryAllocatorStat {
+	pub const fn hand_made(
+		cache_stat: CacheAllocatorStat,
+		rank_count: [usize; MAX_RANK + 1],
+	) -> Self {
+		Self {
+			cache_stat,
+			rank_stat: rank_count,
+		}
+	}
+}
+
+mod tests {
+	use crate::mm::{cache_allocator::CacheStat, constant::PAGE_SHIFT};
+
+	use super::*;
+	use kfs_macro::ktest;
+
+	#[ktest]
+	fn new() {
+		let normal = MemoryAllocator::new();
+		let cache = core::array::from_fn(|_| CacheStat::hand_made(0, 0, 0));
+		let ca_stat = CacheAllocatorStat::hand_made(false, cache);
+		assert_eq!(
+			normal.statistic(),
+			MemoryAllocatorStat::hand_made(ca_stat, [0; MAX_RANK + 1])
+		)
+	}
+
+	#[ktest]
+	fn alloc_dealloc() {
+		for rank in 0..=MAX_RANK {
+			let layout =
+				unsafe { Layout::from_size_align_unchecked(1 << (rank + PAGE_SHIFT), 4096) };
+			let cache = core::array::from_fn(|_| CacheStat::hand_made(0, 0, 0));
+			let ca_stat = CacheAllocatorStat::hand_made(false, cache);
+			let mut rank_count = [0; MAX_RANK + 1];
+			let normal = MemoryAllocator::new();
+
+			let ptr = normal.allocate(layout);
+
+			rank_count[rank] = 1;
+			assert_eq!(
+				normal.statistic(),
+				MemoryAllocatorStat::hand_made(ca_stat, rank_count)
+			);
+
+			// if not dealloc, then panic! will be called.
+			unsafe { normal.deallocate(ptr.unwrap().cast(), layout) };
+
+			rank_count[rank] = 0;
+			assert_eq!(
+				normal.statistic(),
+				MemoryAllocatorStat::hand_made(ca_stat, rank_count)
+			);
+		}
+	}
+
+	#[ktest]
+	fn alloc_twice() {
+		let rank = 2;
+		let layout = unsafe { Layout::from_size_align_unchecked(1 << (rank + PAGE_SHIFT), 4096) };
+		let cache = core::array::from_fn(|_| CacheStat::hand_made(0, 0, 0));
+		let ca_stat = CacheAllocatorStat::hand_made(false, cache);
+		let mut rank_count = [0; MAX_RANK + 1];
+		let normal = MemoryAllocator::new();
+
+		let ptr = [normal.allocate(layout), normal.allocate(layout)];
+
+		rank_count[rank] = 2;
+		assert_eq!(
+			normal.statistic(),
+			MemoryAllocatorStat::hand_made(ca_stat, rank_count)
+		);
+
+		// if not dealloc, then panic! will be called.
+		unsafe { normal.deallocate(ptr[0].unwrap().cast(), layout) };
+		unsafe { normal.deallocate(ptr[1].unwrap().cast(), layout) };
+
+		rank_count[rank] = 0;
+		assert_eq!(
+			normal.statistic(),
+			MemoryAllocatorStat::hand_made(ca_stat, rank_count)
+		);
+	}
+
+	use alloc::vec::Vec;
+
+	#[ktest]
+	fn with_collection() {
+		let normal = MemoryAllocator::new();
+		{
+			let mut v = Vec::new_in(normal);
+			for _ in 0..1000000 {
+				v.push(1);
+			}
+		}
+	}
+}

--- a/src/mm/memory_allocator/mem_atomic.rs
+++ b/src/mm/memory_allocator/mem_atomic.rs
@@ -1,0 +1,20 @@
+use core::{
+	alloc::{AllocError, Allocator, Layout},
+	ptr::NonNull,
+};
+
+use super::MemoryAllocator;
+
+pub static mut ATOMIC_ALLOC: MemoryAllocator = MemoryAllocator::new();
+
+#[derive(Debug)]
+pub struct MemAtomic;
+
+unsafe impl Allocator for MemAtomic {
+	fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+		unsafe { ATOMIC_ALLOC.allocate(layout) }
+	}
+	unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+		ATOMIC_ALLOC.deallocate(ptr, layout)
+	}
+}

--- a/src/mm/memory_allocator/mem_normal.rs
+++ b/src/mm/memory_allocator/mem_normal.rs
@@ -1,0 +1,20 @@
+use core::{
+	alloc::{AllocError, Allocator, Layout},
+	ptr::NonNull,
+};
+
+use super::MemoryAllocator;
+
+pub static mut NORMAL_ALLOC: MemoryAllocator = MemoryAllocator::new();
+
+#[derive(Debug)]
+pub struct MemNormal;
+
+unsafe impl Allocator for MemNormal {
+	fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+		unsafe { NORMAL_ALLOC.allocate(layout) }
+	}
+	unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+		NORMAL_ALLOC.deallocate(ptr, layout)
+	}
+}

--- a/src/mm/memory_allocator/util.rs
+++ b/src/mm/memory_allocator/util.rs
@@ -22,3 +22,8 @@ pub fn level_of(layout: Layout) -> usize {
 
 	LEVEL_MIN + rank.checked_sub(LEVEL_MIN).unwrap_or_default()
 }
+
+pub enum GFP {
+	Atomic,
+	Normal,
+}

--- a/src/mm/memory_allocator/util.rs
+++ b/src/mm/memory_allocator/util.rs
@@ -1,0 +1,24 @@
+use core::alloc::Layout;
+
+use crate::mm::util::bit_scan_reverse;
+
+pub const LEVEL_MIN: usize = 6;
+pub const LEVEL_END: usize = 12;
+
+pub fn level_of(layout: Layout) -> usize {
+	let size = layout.size();
+	let align = layout.align();
+
+	if size <= 1 && align == 1 {
+		return LEVEL_MIN;
+	}
+
+	let rank = unsafe {
+		match size > align {
+			true => bit_scan_reverse(size - 1) + 1,
+			false => bit_scan_reverse(align - 1) + 1,
+		}
+	};
+
+	LEVEL_MIN + rank.checked_sub(LEVEL_MIN).unwrap_or_default()
+}

--- a/src/mm/page_allocator.rs
+++ b/src/mm/page_allocator.rs
@@ -86,7 +86,6 @@ impl PageAllocator {
 	}
 }
 
-#[cfg(asdf)]
 mod mmtest {
 	use crate::{
 		collection::WrapQueue,

--- a/src/mm/page_allocator.rs
+++ b/src/mm/page_allocator.rs
@@ -25,6 +25,8 @@
 //! But, It also reduces maximum allocation size per request by `1 block`.
 
 pub use buddy_allocator::Page;
+pub use constant::MAX_RANK;
+
 pub mod util;
 
 mod buddy_allocator;
@@ -45,6 +47,7 @@ pub struct PageAllocator {
 	normal: BuddyAllocator,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GFP {
 	Normal,
 	High,
@@ -83,6 +86,7 @@ impl PageAllocator {
 	}
 }
 
+#[cfg(asdf)]
 mod mmtest {
 	use crate::{
 		collection::WrapQueue,


### PR DESCRIPTION
* feat: memory allocator
  * refactor the `GlobalAllocator` implementation. 
* refactor: cache allocator
  * remove unnecessary lifetimes.
  * make a `struct CacheAllocator`
  * make a `struct xxStat` to know internal state of the instance. It makes tests convenient more.
  * fix the `SizeCache::deallocate`. I didn't consider reallocating memories that already have freed once or more.
 