### PR TITLE
refactor: lapic reg read/write.

### DIFF
--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -6,3 +6,6 @@ pub mod apic;
 pub mod idt;
 pub mod idte;
 pub mod privilege_level;
+
+pub use apic::LAPIC_PBASE;
+pub use apic::MSR_APIC_BASE;

--- a/src/interrupt/apic.rs
+++ b/src/interrupt/apic.rs
@@ -4,25 +4,26 @@ mod local;
 use crate::interrupt::apic::io::REDIR_TABLE_COUNT;
 use crate::io::pmio::Port;
 use crate::util::arch::cpuid::CPUID;
-use crate::{acpi::IOAPIC_INFO, pr_info, sync::singleton::Singleton, util::arch::msr::Msr};
+use crate::{acpi::IOAPIC_INFO, pr_info, util::arch::msr::Msr};
 
 pub use io::pbase as io_pbase;
 pub use io::vbase as io_vbase;
 pub use local::pbase as local_pbase;
 pub use local::vbase as local_vbase;
+pub use local::PBASE as LAPIC_PBASE;
 
-static MSR_APIC_BASE: Singleton<Msr> = Singleton::new(Msr::new(0x1b));
+pub static MSR_APIC_BASE: Msr = Msr::new(0x1b);
 
 pub fn init() {
 	if CPUID::run(1, 0).edx & 0x100 != 0x100 {
 		panic!("apic unsupported.");
 	}
 
-	if MSR_APIC_BASE.lock().read().low & 0x800 != 0x800 {
+	if MSR_APIC_BASE.read().low & 0x800 != 0x800 {
 		panic!("apic disabled.");
 	}
 
-	if local::Register::SpuriousInterruptVector.read()[0] & 0x100 != 0x100 {
+	if local::Register::SpuriousInterruptVector.read() & 0x100 != 0x100 {
 		panic!("apic disabled.");
 	}
 

--- a/src/mm/page/arch/init.rs
+++ b/src/mm/page/arch/init.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use super::directory::GLOBAL_PD_VIRT;
 use super::CURRENT_PD;
 use super::{util::invalidate_all_tlb, PageFlag, PDE};
@@ -14,6 +16,7 @@ pub struct VMemory {
 	pub vmalloc_pfn: Range<usize>,
 	pub high_pfn: Range<usize>,
 	pub local_apic_pfn: usize,
+	pub io_apic_pfn: Vec<usize>,
 }
 
 const ZONE_NORMAL_START: usize = VM_OFFSET / PT_COVER_SIZE;
@@ -53,6 +56,7 @@ pub unsafe fn init() {
 		vmalloc_pfn: vmalloc_start..vmalloc_end,
 		high_pfn: high_start..high_end,
 		local_apic_pfn: 0,
+		io_apic_pfn: Vec::new(),
 	});
 
 	CURRENT_PD.write(&mut GLOBAL_PD_VIRT);

--- a/src/mm/page/arch/mmio.rs
+++ b/src/mm/page/arch/mmio.rs
@@ -1,6 +1,5 @@
 mod apic;
 
 pub unsafe fn init() {
-	apic::mapping_local_apic_registers().expect("mapping local apic");
-	apic::mapping_io_apic_registers().expect("mapping io apic");
+	apic::init();
 }


### PR DESCRIPTION
* remove Vec in read/write logic.
* add read/write logic for registers bigger than usize
* refactor pbase() function from running MSR read by every call to returning LAPIC_PBASE static variable.
* add io_apic_pfn field to Vmemory