### PR TITLE
sys_exit, yield_now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,6 @@ run : rescue
 	@scripts/qemu.sh $(RESCUE_IMG) stdio -monitor pty
 
 .PHONY : debug
-debug : RUSTC_FLAG += --cfg ktest
-debug : RUSTC_FLAG += --cfg ktest='"all"'
 ifeq ($(DEBUG_WITH_VSCODE),y)
 debug : $(RESCUE_IMG) $(KERNEL_DEBUG_SYMBOL)
 	@scripts/vsc-debug.py $(KERNEL_DEBUG_SYMBOL) $(KERNEL_BIN) &

--- a/src/asm/entry.S
+++ b/src/asm/entry.S
@@ -7,8 +7,10 @@ extern kernel_entry
 extern load_flat_gdt
 
 section .stack nobits write
-global kernel_stack_bottom
+global kernel_stack_top
+kernel_stack_top:
     resb STACK_SIZE
+global kernel_stack_bottom
 kernel_stack_bottom:
 
 section .text

--- a/src/asm/interrupt.S
+++ b/src/asm/interrupt.S
@@ -1,6 +1,8 @@
 %include "segment.S"
 %include "common.S"
 
+extern switch_task_finish
+
 ; INTERRUPT_HANDLER(name: ident, callback: ident, has_error_code: bool)
 ; define new interrupt handler.
 ; 
@@ -70,6 +72,9 @@ return_from_interrupt:
 
     iret
 
+; Calling convention: gcc fastcall
+;  - arg1: ecx
+;  - arg2: edx
 global switch_stack
 switch_stack:
     ; save callee-saved registers
@@ -78,29 +83,12 @@ switch_stack:
     push edi
     push ebx
 
-    mov esi, [esp + 24] ; next_stack
-    mov edi, [esp + 20] ; prev_stack
-
-    ; do stack switching with atomic operations.
-    lfence
-    xchg [edi], esp
-    xchg esp, [esi]
-    sfence
+    mov [ecx], esp
+    mov esp, [edx]
 
     pop ebx
     pop edi
     pop esi
     pop ebp
 
-    ret
-
-global kthread_exec
-kthread_exec:
-    mov esp, [esp + 4]
-    add esp, 16
-    ret
-
-global user_process_exec
-user_process_exec:
-    mov esp, [esp + 4]
-    jmp return_from_interrupt
+    jmp switch_task_finish

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -12,6 +12,7 @@ use crate::pr_info;
 
 pub use stack_dump::StackDump;
 pub use stackframe_iter::kernel_stack_bottom;
+pub use stackframe_iter::kernel_stack_top;
 
 pub struct Backtrace {
 	stack: StackDump,

--- a/src/backtrace/stackframe_iter.rs
+++ b/src/backtrace/stackframe_iter.rs
@@ -4,6 +4,8 @@ extern "C" {
 	/// Do not __call__ this function. it's not function at all.
 	/// but just pointer, which points bottom of the kernel stack.
 	pub fn kernel_stack_bottom();
+
+	pub fn kernel_stack_top();
 }
 
 pub struct StackframeIter {

--- a/src/interrupt/hw/apic_timer.rs
+++ b/src/interrupt/hw/apic_timer.rs
@@ -1,43 +1,13 @@
-use crate::{
-	interrupt::{apic::local::LOCAL_APIC, InterruptFrame},
-	process::{
-		context::{cpu_context, switch_stack, context_switch, InContext},
-		task::{CURRENT, TASK_QUEUE},
-	},
-	sync::cpu_local::CpuLocal,
-};
+use crate::interrupt::{apic::local::LOCAL_APIC, InterruptFrame};
+use crate::process::task::yield_now;
+use crate::sync::cpu_local::CpuLocal;
 
 #[no_mangle]
 pub unsafe extern "C" fn handle_timer_impl(_frame: InterruptFrame) {
 	*JIFFIES.get_mut() += 1;
 	LOCAL_APIC.end_of_interrupt();
 
-	if let InContext::PreemptDisabled = cpu_context() {
-		return;
-	}
-
-	let backup = context_switch(InContext::HwIrq);
-	let task_q = unsafe { TASK_QUEUE.lock_manual() };
-
-	// safety: this function always called through interrupt gate.
-	// so IRQ is disabled.
-	let current = unsafe { CURRENT.get_mut() };
-
-	let next = match task_q.pop_front() {
-		Some(x) => x,
-		None => return,
-	};
-	task_q.push_back(next.clone());
-
-	let prev_stack = unsafe { current.get_manual().esp_mut() };
-	let next_stack = unsafe { next.get_manual().esp_mut() };
-
-	core::mem::drop(core::mem::replace(current, next));
-
-	switch_stack(prev_stack, next_stack);
-
-	unsafe { TASK_QUEUE.unlock_manual() }
-	context_switch(backup);
+	yield_now();
 }
 
 static JIFFIES: CpuLocal<usize> = CpuLocal::new(0);

--- a/src/mm/page/arch/directory.rs
+++ b/src/mm/page/arch/directory.rs
@@ -13,6 +13,7 @@ extern "C" {
 
 pub static KERNEL_PD: Singleton<PD> = Singleton::uninit();
 
+#[repr(transparent)]
 pub struct PD {
 	inner: NonNull<[PDE; 1024]>,
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,4 +1,16 @@
+use crate::backtrace::kernel_stack_top;
+
+use self::task::{Stack, Task, CURRENT};
+
 pub mod context;
 pub mod kthread;
 pub mod task;
 pub mod user_space;
+
+pub fn init() {
+	let kstack = unsafe { Stack::from_raw(kernel_stack_top as usize as *mut _) };
+
+	let idle_task = Task::alloc_new(kstack).unwrap();
+
+	CURRENT.init(idle_task);
+}

--- a/src/process/user_space.rs
+++ b/src/process/user_space.rs
@@ -1,102 +1,102 @@
 //! early stage user space
 
-use core::{arch::asm, ptr::NonNull};
+// use core::{arch::asm, ptr::NonNull};
 
-use crate::{
-	interrupt::InterruptFrame,
-	mm::{
-		alloc::{page, Zone},
-		constant::PAGE_SIZE,
-		page::{map_page, PageFlag},
-		util::{size_to_rank, virt_to_phys},
-	},
-	process::context::{context_switch, InContext},
-	x86::{CPU_STACK, DPL_USER, GDT},
-};
+// use crate::{
+// 	interrupt::InterruptFrame,
+// 	mm::{
+// 		alloc::{page, Zone},
+// 		constant::PAGE_SIZE,
+// 		page::{map_page, PageFlag},
+// 		util::{size_to_rank, virt_to_phys},
+// 	},
+// 	process::context::{context_switch, InContext},
+// 	x86::{DPL_USER, GDT},
+// };
 
-extern "C" {
-	fn user_start();
-	fn user_end();
-}
+// extern "C" {
+// 	fn user_start();
+// 	fn user_end();
+// }
 
-const USER_SPACE_BEGIN: usize = 0xb000_0000;
-const TEMP_SPACE_BEGIN: usize = 0xa000_0000;
+// const USER_SPACE_BEGIN: usize = 0xb000_0000;
+// const TEMP_SPACE_BEGIN: usize = 0xa000_0000;
 
-pub unsafe fn copy_to_user(from: *const u8, mut ptr: NonNull<[u8]>, size: usize) {
-	let slice = ptr.as_mut();
-	let raw_ptr = slice.as_ptr();
-	let ptr_len = slice.len();
+// pub unsafe fn copy_to_user(from: *const u8, mut ptr: NonNull<[u8]>, size: usize) {
+// 	let slice = ptr.as_mut();
+// 	let raw_ptr = slice.as_ptr();
+// 	let ptr_len = slice.len();
 
-	let mut remain = size;
-	for x in 0..(ptr_len / PAGE_SIZE) {
-		let dst = raw_ptr.add(x * PAGE_SIZE);
-		let src = from.add(x * PAGE_SIZE);
+// 	let mut remain = size;
+// 	for x in 0..(ptr_len / PAGE_SIZE) {
+// 		let dst = raw_ptr.add(x * PAGE_SIZE);
+// 		let src = from.add(x * PAGE_SIZE);
 
-		map_page(
-			TEMP_SPACE_BEGIN,
-			virt_to_phys(dst as usize),
-			PageFlag::Present | PageFlag::Write,
-		)
-		.unwrap();
+// 		map_page(
+// 			TEMP_SPACE_BEGIN,
+// 			virt_to_phys(dst as usize),
+// 			PageFlag::Present | PageFlag::Write,
+// 		)
+// 		.unwrap();
 
-		map_page(
-			USER_SPACE_BEGIN + x * PAGE_SIZE,
-			virt_to_phys(dst as usize),
-			PageFlag::Present | PageFlag::Write | PageFlag::User,
-		)
-		.unwrap();
+// 		map_page(
+// 			USER_SPACE_BEGIN + x * PAGE_SIZE,
+// 			virt_to_phys(dst as usize),
+// 			PageFlag::Present | PageFlag::Write | PageFlag::User,
+// 		)
+// 		.unwrap();
 
-		(TEMP_SPACE_BEGIN as *mut u8).write_bytes(0, PAGE_SIZE);
-		(TEMP_SPACE_BEGIN as *mut u8).copy_from_nonoverlapping(src, PAGE_SIZE.min(remain));
-		remain -= PAGE_SIZE.min(remain);
+// 		(TEMP_SPACE_BEGIN as *mut u8).write_bytes(0, PAGE_SIZE);
+// 		(TEMP_SPACE_BEGIN as *mut u8).copy_from_nonoverlapping(src, PAGE_SIZE.min(remain));
+// 		remain -= PAGE_SIZE.min(remain);
 
-		// TODO: TEMP_SPACE TLB flushing
-	}
-}
+// 		// TODO: TEMP_SPACE TLB flushing
+// 	}
+// }
 
-extern "C" {
-	fn user_process_exec(esp: *mut usize) -> !;
-}
+// extern "C" {
+// 	fn user_process_exec(esp: *mut usize) -> !;
+// }
 
-pub unsafe fn exec_user_space() -> ! {
-	let total_size = user_end as usize - user_start as usize;
+// pub unsafe fn exec_user_space() -> ! {
+// 	let total_size = user_end as usize - user_start as usize;
 
-	let storage = page::alloc_pages(size_to_rank(total_size), Zone::High).unwrap();
+// 	let storage = page::alloc_pages(size_to_rank(total_size), Zone::High).unwrap();
 
-	copy_to_user(user_start as usize as *mut u8, storage, total_size);
+// 	copy_to_user(user_start as usize as *mut u8, storage, total_size);
 
-	let mut new_eflags: usize;
-	asm!("pushfd", "pop {eflags}", eflags = out(reg) new_eflags);
+// 	let mut new_eflags: usize;
+// 	asm!("pushfd", "pop {eflags}", eflags = out(reg) new_eflags);
 
-	// set IF (enable interrupt)
-	new_eflags |= 1 << 9;
+// 	// set IF (enable interrupt)
+// 	new_eflags |= 1 << 9;
 
-	context_switch(InContext::IrqDisabled);
-	let stack = CPU_STACK.get_mut();
+// 	context_switch(InContext::IrqDisabled);
+// 	let stack = CPU_STACK.get_mut();
 
-	stack
-		.as_mut_ptr()
-		.cast::<InterruptFrame>()
-		.write(InterruptFrame {
-			ebp: 0,
-			edi: 0,
-			esi: 0,
-			edx: 0,
-			ecx: 0,
-			ebx: 42,
-			eax: 0,
-			ds: GDT::USER_DATA | DPL_USER,
-			es: GDT::USER_DATA | DPL_USER,
-			fs: GDT::USER_DATA | DPL_USER,
-			gs: GDT::USER_DATA | DPL_USER,
-			handler: 0,
-			error_code: 0,
-			eip: USER_SPACE_BEGIN,
-			cs: GDT::USER_CODE | DPL_USER,
-			eflags: new_eflags,
-			esp: 0,
-			ss: GDT::USER_DATA | DPL_USER,
-		});
+// 	stack
+// 		.as_mut_ptr()
+// 		.cast::<InterruptFrame>()
+// 		.write(InterruptFrame {
+// 			ebp: 0,
+// 			edi: 0,
+// 			esi: 0,
+// 			edx: 0,
+// 			ecx: 0,
+// 			ebx: 42,
+// 			eax: 0,
+// 			ds: GDT::USER_DATA | DPL_USER,
+// 			es: GDT::USER_DATA | DPL_USER,
+// 			fs: GDT::USER_DATA | DPL_USER,
+// 			gs: GDT::USER_DATA | DPL_USER,
+// 			handler: 0,
+// 			error_code: 0,
+// 			eip: USER_SPACE_BEGIN,
+// 			cs: GDT::USER_CODE | DPL_USER,
+// 			eflags: new_eflags,
+// 			esp: 0,
+// 			ss: GDT::USER_DATA | DPL_USER,
+// 		});
 
-	unsafe { user_process_exec((&*stack) as *const _ as usize as *mut usize) }
-}
+// 	unsafe { user_process_exec((&*stack) as *const _ as usize as *mut usize) }
+// }


### PR DESCRIPTION
`sys_exit(exit_code: usize)`: terminate current task. (process, thread, ... whatever)
`yield_now()`: suspend current task immediately. and execute next task. (like linux's `schedule()`)
