### PR TITLE
feat: atomic macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,12 @@ fn run_test() -> ! {
 	let n_test = tests.len();
 
 	for (i, test) in tests.iter().enumerate() {
-		pr_info!("Test [{}/{}]: {}", i + 1, n_test, test.get_name());
+		pr_info!(
+			"\x1b[33mTest [{}/{}]\x1b[39m: {}",
+			i + 1,
+			n_test,
+			test.get_name()
+		);
 		test.run();
 		pr_info!("...\x1b[32mPASS\x1b[39m");
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,10 @@ fn open_default_fd(task: &mut Arc<Task>) {
 	let ext = task.get_user_ext().expect("user task");
 	let sess = &ext.lock_relation().get_session();
 
-	tty.lock().connect(Arc::downgrade(sess));
-	sess.lock().set_ctty(tty.clone());
+	atomic_operation! {
+		tty.lock().connect(Arc::downgrade(sess));
+		sess.lock().set_ctty(tty.clone());
+	}
 
 	let mut fd_table = ext.lock_fd_table();
 	let file = Arc::new(File {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -2,5 +2,6 @@ mod lock;
 pub use lock::spinlock;
 pub use lock::TryLockFail;
 
+pub mod atomic;
 pub mod cpu_local;
 pub mod locked;

--- a/src/sync/atomic.rs
+++ b/src/sync/atomic.rs
@@ -4,7 +4,35 @@ macro_rules! atomic_operation {
 		{
 			let __irq_save = crate::sync::spinlock::irq_save();
 			$($tt)*
-		};
-		let __final_line_guard = 0;
+		}
 	};
+}
+
+mod test {
+	use kfs_macro::ktest;
+
+	use crate::sync::locked::Locked;
+
+	struct A(usize);
+	struct B(isize);
+	struct C(usize);
+
+	static LOCK_A1: Locked<A> = Locked::new(A(1));
+	static LOCK_B1: Locked<B> = Locked::new(B(1));
+	static LOCK_C1: Locked<C> = Locked::new(C(2));
+
+	#[ktest(atomic_op)]
+	fn test() {
+		fn func() -> usize {
+			let _c_lock = LOCK_C1.lock();
+			atomic_operation! {
+				let a = LOCK_A1.lock().0;
+				let b = LOCK_B1.lock().0 as usize;
+				assert_eq!(a + b, 2);
+				a + b
+			}
+		}
+
+		let _ret = func();
+	}
 }

--- a/src/sync/atomic.rs
+++ b/src/sync/atomic.rs
@@ -1,0 +1,10 @@
+#[macro_export]
+macro_rules! atomic_operation {
+	($($tt:tt)*) => {
+		{
+			let __irq_save = crate::sync::spinlock::irq_save();
+			$($tt)*
+		};
+		let __final_line_guard = 0;
+	};
+}

--- a/src/sync/locked.rs
+++ b/src/sync/locked.rs
@@ -82,6 +82,12 @@ impl<'lock, T> LockedGuard<'lock, T> {
 impl<'lock, T> Drop for LockedGuard<'lock, T> {
 	fn drop(&mut self) {
 		self.locked.inner.unlock();
+
+		#[cfg(ktest = "atomic_op")]
+		{
+			use crate::pr_debug;
+			pr_debug!("{}", core::any::type_name::<T>());
+		}
 	}
 }
 


### PR DESCRIPTION
macro for lock atomic operation.

Some procedures needed locks more than two should ensure atomic operation.

In order to ensure this, just hold one lock while whole operation ends.

But It can be cause dead lock according to lock order.

I don't want to check whole lock orders across codes.

So, I made `irq_save` and `irq_restore` function with `lock_depth`.

Also, I made a macro named `atomic_operation` for easy to use.


