### PR TITLE
feat: unmmapped

### DIFF
--- a/src/mm/alloc/cache/meta_cache.rs
+++ b/src/mm/alloc/cache/meta_cache.rs
@@ -4,7 +4,7 @@ use core::ptr::NonNull;
 
 use super::no_alloc_list::{NAList, Node};
 
-use crate::mm::{page::ptr_to_meta, util::*};
+use crate::mm::{page::phys_to_meta, util::*};
 
 #[derive(Debug)]
 pub struct Dummy;
@@ -107,8 +107,12 @@ impl MetaCache {
 	}
 }
 
-pub fn get_rank(ptr: NonNull<u8>) -> usize {
-	unsafe { ptr_to_meta(ptr).as_ref().rank() }
+fn get_rank(ptr: NonNull<u8>) -> usize {
+	unsafe {
+		phys_to_meta(virt_to_phys(ptr.as_ptr() as usize))
+			.as_ref()
+			.rank()
+	}
 }
 
 #[inline(always)]

--- a/src/mm/alloc/cache/size_cache.rs
+++ b/src/mm/alloc/cache/size_cache.rs
@@ -60,7 +60,7 @@ impl<const N: usize> SizeCache<N> {
 	}
 
 	fn alloc_pages(&mut self, rank: usize) -> Result<NonNull<[u8]>> {
-		let page = page::alloc_pages(rank, Zone::Normal)?;
+		let page = unsafe { page::alloc_pages(rank, Zone::Normal)?.as_mapped() };
 		self.page_count += 1 << rank;
 		Ok(page)
 	}

--- a/src/mm/alloc/cache/traits.rs
+++ b/src/mm/alloc/cache/traits.rs
@@ -5,6 +5,7 @@ use super::meta_cache::MetaCache;
 use super::no_alloc_list::NAList;
 
 use crate::mm::alloc::page;
+use crate::ptr::UnMapped;
 
 pub trait CacheTrait {
 	fn partial(&mut self) -> &mut NAList<MetaCache>;
@@ -19,7 +20,7 @@ pub trait CacheTrait {
 		satisfied.iter_mut().for_each(|meta_cache| unsafe {
 			let ptr = meta_cache as *mut MetaCache;
 			let ptr = NonNull::new_unchecked(ptr.cast());
-			page::free_pages(ptr);
+			page::free_pages(UnMapped::from_normal(ptr));
 		});
 	}
 

--- a/src/mm/alloc/page.rs
+++ b/src/mm/alloc/page.rs
@@ -2,17 +2,19 @@ mod buddy_allocator;
 mod free_list;
 mod page_allocator;
 
+use crate::ptr::UnMapped;
+
 use super::Zone;
-use core::{alloc::AllocError, ptr::NonNull};
+use core::alloc::AllocError;
 use page_allocator::{PageAlloc, PAGE_ALLOC};
 
-pub fn alloc_pages(rank: usize, zone: Zone) -> Result<NonNull<[u8]>, AllocError> {
+pub fn alloc_pages(rank: usize, zone: Zone) -> Result<UnMapped, AllocError> {
 	let mut page_alloc = PAGE_ALLOC.lock();
 
 	unsafe { page_alloc.assume_init_mut().alloc_pages(rank, zone) }
 }
 
-pub fn free_pages(page: NonNull<u8>) {
+pub fn free_pages(page: UnMapped) {
 	let mut page_alloc = PAGE_ALLOC.lock();
 
 	unsafe { page_alloc.assume_init_mut().free_pages(page) };

--- a/src/mm/alloc/page/page_allocator.rs
+++ b/src/mm/alloc/page/page_allocator.rs
@@ -97,8 +97,6 @@ mod test {
 
 	#[derive(Clone, Debug)]
 	struct AllocInfo {
-		// ptr: NonNull<u8>,
-		// rank: usize,
 		ptr: UnMapped,
 	}
 

--- a/src/mm/alloc/page/page_allocator.rs
+++ b/src/mm/alloc/page/page_allocator.rs
@@ -61,8 +61,6 @@ impl PageAlloc {
 	/// Deallocate pages.
 	pub fn free_pages(&mut self, page: UnMapped) {
 		let pfn = addr_to_pfn(page.as_phys());
-
-		// let rank = unsafe { index_to_meta(pfn).as_ref() }.rank();
 		self.available_pages += rank_to_pages(page.rank());
 
 		if pfn < unsafe { MEM_INFO.high_start_pfn } {

--- a/src/mm/alloc/phys/memory_allocator.rs
+++ b/src/mm/alloc/phys/memory_allocator.rs
@@ -4,6 +4,7 @@ use core::ptr::NonNull;
 use crate::mm::alloc::cache::{CacheAllocator, CacheAllocatorStat};
 use crate::mm::alloc::{page, Zone};
 use crate::mm::{constant::*, util::*};
+use crate::ptr::UnMapped;
 
 #[derive(Debug)]
 pub struct PMemAlloc {
@@ -51,7 +52,7 @@ impl PMemAlloc {
 			None => cache.allocate(level),
 			Some(rank) => {
 				rank_count[rank] += 1;
-				page::alloc_pages(rank, Zone::Normal)
+				page::alloc_pages(rank, Zone::Normal).map(|um| unsafe { um.as_mapped() })
 			}
 		}
 	}
@@ -64,7 +65,7 @@ impl PMemAlloc {
 			None => cache.deallocate(ptr, level),
 			Some(rank) => {
 				rank_count[rank] -= 1;
-				page::free_pages(ptr);
+				page::free_pages(UnMapped::from_normal(ptr));
 			}
 		}
 	}

--- a/src/mm/page.rs
+++ b/src/mm/page.rs
@@ -6,7 +6,7 @@ use core::ptr::NonNull;
 pub use arch::*;
 pub(crate) use os::metapage_let;
 pub use os::{
-	alloc_meta_page_table, index_to_meta, meta_to_index, meta_to_ptr, ptr_to_meta, MetaPage,
+	alloc_meta_page_table, index_to_meta, meta_to_index, meta_to_unmapped, phys_to_meta, MetaPage,
 };
 
 pub unsafe fn init_metapage_table(table: NonNull<[MetaPage]>) {

--- a/src/mm/page/arch/table.rs
+++ b/src/mm/page/arch/table.rs
@@ -21,10 +21,11 @@ impl PT {
 	}
 
 	pub fn new_from_4m(pde_4m: PDE) -> Result<&'static mut Self, AllocError> {
-		let addr = pde_4m.addr();
+		let addr = pde_4m.paddr();
 		let flag = pde_4m.flag();
 		unsafe {
 			let page_table = page::alloc_pages(0, Zone::Normal)?
+				.as_mapped()
 				.as_mut()
 				.as_mut_ptr()
 				.cast::<PT>();
@@ -79,7 +80,7 @@ impl PTE {
 		self.data = flag
 	}
 
-	pub fn addr(&self) -> usize {
+	pub fn paddr(&self) -> usize {
 		(self.data.bits() & Self::ADDR_MASK) as usize
 	}
 

--- a/src/mm/user/memory.rs
+++ b/src/mm/user/memory.rs
@@ -1,14 +1,13 @@
 use core::alloc::AllocError;
-use core::ptr::NonNull;
 use core::slice::from_raw_parts;
 
 use crate::config::TRAMPOLINE_BASE;
 use crate::mm::alloc::page::free_pages;
 use crate::mm::alloc::virt::{kmap, kunmap};
 use crate::mm::alloc::Zone;
+use crate::mm::constant::*;
 use crate::mm::page::{get_zero_page_phys, PageFlag, PD};
-use crate::mm::{constant::*, util::*};
-use crate::ptr::PageBox;
+use crate::ptr::{PageBox, UnMapped};
 use crate::syscall::errno::Errno;
 
 use super::copy::{copy_user_to_user_page, memset_to_user_page};
@@ -217,7 +216,7 @@ impl Drop for Memory {
 			let paddr = pd.lookup(vaddr)?;
 
 			if get_zero_page_phys() != paddr {
-				free_pages(unsafe { NonNull::new_unchecked(phys_to_virt(paddr) as *mut u8) })
+				free_pages(UnMapped::from_phys(paddr))
 			}
 
 			Some(())


### PR DESCRIPTION
I was so confused whether a return of `alloc_pages` function is mapped or not.

So, I made `UnMapped` pointer for page allocation.

If you use `alloc_pages` with Zone::Normal, just call `as_mapped` method and use the allocated memory.

It passes tests. But, please read codes line by line "very carefully".

And,

I think `META_PAGE_TABLE` is not working atomically.

What do you think about this?