### PR TITLE
trace-feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,4 +10,5 @@ rustflags = [
 	"-C", "panic=abort",
 	"-C", "relocation-model=static",
 	'--cfg', 'log_level="debug"', # ALL = debug > info > warn > error
+	'--cfg', 'trace_feature="ext2-unmount"',
 ]

--- a/scripts/trace-feature.py
+++ b/scripts/trace-feature.py
@@ -4,19 +4,21 @@ import re
 # Define the project directory
 project_directory = './'
 
-# Regular expression pattern to match 'trace_feature!("feat-name", .*)' with optional additional arguments
-pattern = r'trace_feature!\s*\(\s*("[^"]+").*\)'
+# Regular expression pattern to match 'trace_feature' lines and extract feature names
+pattern = r'trace_feature!\s*\(\s*("[^"]+"\s*(?:\|\s*"[^"]+")*)\s*,\s*.*\)'
 
-# Function to search for and extract feature names
+# Function to search for 'trace_feature' lines and extract feature names
 def extract_feature_names(file_path):
     feature_names = []
     with open(file_path, 'r') as file:
         content = file.read()
         matches = re.findall(pattern, content)
-        feature_names.extend(matches)
+        for match in matches:
+            names = re.findall(r'"([^"]+)"', match)
+            feature_names.extend(names)
     return feature_names
 
-# Function to search for 'trace_feature!("feat-name", .*)' in Rust files
+# Function to search for 'trace_feature' in Rust files
 def search_for_trace_feature(directory):
     feature_names = []
     for root, _, files in os.walk(directory):
@@ -26,10 +28,10 @@ def search_for_trace_feature(directory):
                 feature_names.extend(extract_feature_names(file_path))
     return feature_names
 
-# Call the function to search for 'trace_feature!("feat-name", .*)' in Rust files and print the extracted feature names
+# Call the function to search for 'trace_feature' in Rust files and print the extracted feature names
 feature_names = search_for_trace_feature(project_directory)
-unique_feature_names = set(feature_names)
+feature_set = set(feature_names)
 
-print('[Trace Feature List]:')
-for name in unique_feature_names:
+print("[Trace fature list]")
+for name in sorted(feature_set):
     print(name.strip('"'))

--- a/scripts/trace-feature.py
+++ b/scripts/trace-feature.py
@@ -1,0 +1,35 @@
+import os
+import re
+
+# Define the project directory
+project_directory = './'
+
+# Regular expression pattern to match 'trace_feature!("feat-name", .*)' with optional additional arguments
+pattern = r'trace_feature!\s*\(\s*("[^"]+").*\)'
+
+# Function to search for and extract feature names
+def extract_feature_names(file_path):
+    feature_names = []
+    with open(file_path, 'r') as file:
+        content = file.read()
+        matches = re.findall(pattern, content)
+        feature_names.extend(matches)
+    return feature_names
+
+# Function to search for 'trace_feature!("feat-name", .*)' in Rust files
+def search_for_trace_feature(directory):
+    feature_names = []
+    for root, _, files in os.walk(directory):
+        for file in files:
+            if file.endswith('.rs'):
+                file_path = os.path.join(root, file)
+                feature_names.extend(extract_feature_names(file_path))
+    return feature_names
+
+# Call the function to search for 'trace_feature!("feat-name", .*)' in Rust files and print the extracted feature names
+feature_names = search_for_trace_feature(project_directory)
+unique_feature_names = set(feature_names)
+
+print('[Trace Feature List]:')
+for name in unique_feature_names:
+    print(name.strip('"'))

--- a/src/printk.rs
+++ b/src/printk.rs
@@ -1,3 +1,5 @@
+mod pr_log;
 mod printk;
 
+pub use pr_log::*;
 pub use printk::*;

--- a/src/printk/pr_log.rs
+++ b/src/printk/pr_log.rs
@@ -1,0 +1,20 @@
+#[macro_export]
+macro_rules! trace_feature {
+	($($feat:literal $(|)?)*, $($arg:tt)*) => {
+		#[cfg(all(log_level = "debug", any($(trace_feature = $feat),*)))]
+		{
+			$(
+				if cfg!(trace_feature = $feat) {
+				    $crate::printk!("{}: ", $feat);
+				}
+			)*
+
+			let path = core::module_path!();
+			if let Some(pos) = path.find("::") {
+				$crate::printk!("<{}> ", &path[(pos + 2)..]);
+			}
+
+			$crate::printkln!($($arg)*);
+		}
+	};
+}


### PR DESCRIPTION
- `trace_feature!("feature-name", "debug-message");` 로 작성하면, 해당 feature에 대한 trace를 켰을 때만 디버그 메시지가 나옵니다.

- `trace_feature!("feature-name" | "feature-name2", "debug-message");` 연산자`|`를 통해 디버그 메시지에 여러 feature를 줄 수 있습니다.


<img width="755" alt="Screen Shot 2023-10-08 at 8 14 53 AM" src="https://github.com/exciting-kfs/kfs/assets/56795942/a17372a3-f3b1-4195-ba3e-f61adf68de25">


- scripts/trace-feature.py를 통해 feature list를 확인할 수 있습니다.