### PR TITLE
fix: receive ignored signals -> ignore.

### DIFF
--- a/src/process/signal.rs
+++ b/src/process/signal.rs
@@ -84,6 +84,11 @@ impl Signal {
 			return;
 		}
 
+		let table = self.table.lock();
+		if let SigHandler::Ignore = table[info.num.index()] {
+			return;
+		}
+
 		let mut queue = self.queue.lock();
 
 		use SigNum::*;
@@ -204,8 +209,8 @@ impl Signal {
 	}
 
 	fn get_signal_event(&self) -> Option<SigInfo> {
-		let mut queue = self.queue.lock();
 		let mask = self.mask.lock();
+		let mut queue = self.queue.lock();
 
 		let mut ret = None;
 		let mut not = LinkedList::new();
@@ -217,7 +222,7 @@ impl Signal {
 				break;
 			}
 		}
-		queue.extend(not);
+		queue.append(&mut not);
 
 		ret
 	}

--- a/userspace/getty/getty.c
+++ b/userspace/getty/getty.c
@@ -473,7 +473,7 @@ void get_login_shell() {
 	if (pid == 0) {
 		signal(SIGINT, SIG_DFL);
 		signal(SIGQUIT, SIG_DFL);
-		setsid();
+		// setsid();
 		setuid(ent->uid);
 		setgid(ent->gid);
 		chdir(ent->home);


### PR DESCRIPTION
#### fix: receive ignored signals -> ignore
  Before this patch, When a process received an ignored signal, it was pending in sig queue.
  The process affected when it started receiving that signal.
  Now, a process that receives ignored signal will not push it to the queue.

#### feat: shell: builtin_exec