### PR TITLE
fix: UB on Partition::validate_bid

### DIFF
--- a/src/driver/partition.rs
+++ b/src/driver/partition.rs
@@ -191,7 +191,7 @@ impl Partition {
 		let entry = unsafe { self.entry.get_unchecked() };
 		let lba = entry.begin().block_size_add(self.block_size(), maybe_bid)?;
 
-		(lba < entry.end()).then_some(unsafe { BlockId::new_unchecked(maybe_bid) })
+		(lba < entry.end()).then(|| unsafe { BlockId::new_unchecked(maybe_bid) })
 	}
 
 	fn bid_to_lba(&self, bid: BlockId) -> LBA28 {


### PR DESCRIPTION
tldr: the code inside bool::then_some is always executed, but the code in the closure from bool::then is only executed if is true.

This is UB, because the bool::then_some is a function that takes a bool and a generic value, because of that, the value inside of it is always evaluated, independent if the bool is true/false.

it's clear if the desugarize the syntax:

```rust
// first we get the true/false for the condition
let cond: bool = lba < entry.end();
// then we evaluate the expression to pass the value as parameter
// UB here, the is executed always, independent of the cond being true/false
let value = unsafe { BlockId::new_unchecked(maybe_bid) };
// then we call the function `bool::then_some`.
bool::then_some(cond, value)
```

The solution is simply change it to bool::then, because the parameter it's a closure, it's lazy evaluated, and only executed if the condition is true.

As mentioned at https://github.com/rust-lang/rust/blob/5cb2e7dfc362662b0036faad3bab88d73027fd05/src/tools/clippy/clippy_lints/src/transmute/mod.rs#L468-L520

And presented at https://youtu.be/hBjQ3HqCfxs?si=nrIz6ZHnxEHO6Pik&t=53
